### PR TITLE
feat: Create custom alarm integration for Home Assistant

### DIFF
--- a/custom_components/alarme_personnalisee/__init__.py
+++ b/custom_components/alarme_personnalisee/__init__.py
@@ -1,0 +1,25 @@
+"""The Alarme Personnalisée integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
+
+from .const import DOMAIN
+
+# For now, we only have the alarm_control_panel platform.
+PLATFORMS: list[Platform] = [Platform.ALARM_CONTROL_PANEL]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Alarme Personnalisée from a config entry."""
+    # This will forward the setup to the alarm_control_panel.py file.
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    # This will unload the alarm_control_panel platform.
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/alarme_personnalisee/alarm_control_panel.py
+++ b/custom_components/alarme_personnalisee/alarm_control_panel.py
@@ -1,0 +1,131 @@
+"""Platform for alarm control panel integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntity,
+    AlarmControlPanelEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_VACATION,
+    STATE_ALARM_DISARMED,
+    STATE_ALARM_TRIGGERED,
+)
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the alarm control panel platform."""
+    async_add_entities([AlarmePersonnaliseeEntity(entry)])
+
+
+class AlarmePersonnaliseeEntity(AlarmControlPanelEntity):
+    """Representation of an Alarme Personnalisée."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the alarm control panel."""
+        self._entry = entry
+        self._attr_unique_id = entry.entry_id
+        self._attr_name = "Alarme"
+        self._state = STATE_ALARM_DISARMED
+
+        # Get sensor lists from config entry
+        self._away_sensors = self._entry.data.get("away_sensors", [])
+        self._home_sensors = self._entry.data.get("home_sensors", [])
+        self._vacation_sensors = self._entry.data.get("vacation_sensors", [])
+
+        # Combine all sensors into one list for the listener
+        self._all_sensors = list(
+            set(self._away_sensors + self._home_sensors + self._vacation_sensors)
+        )
+        self._unsub_listener = None
+
+    @property
+    def state(self) -> str | None:
+        """Return the state of the entity."""
+        return self._state
+
+    @property
+    def supported_features(self) -> AlarmControlPanelEntityFeature:
+        """Return the list of supported features."""
+        return (
+            AlarmControlPanelEntityFeature.ARM_HOME
+            | AlarmControlPanelEntityFeature.ARM_AWAY
+            | AlarmControlPanelEntityFeature.ARM_VACATION
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self._unsub_listener = async_track_state_change_event(
+            self.hass, self._all_sensors, self._sensor_state_changed
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        if self._unsub_listener:
+            self._unsub_listener()
+
+    @callback
+    def _sensor_state_changed(self, event: Event) -> None:
+        """Handle sensor state changes."""
+        new_state = event.data.get("new_state")
+        if new_state is None or new_state.state != "on":
+            return
+
+        entity_id = event.data.get("entity_id")
+
+        if self._state == STATE_ALARM_DISARMED:
+            return
+
+        triggered = False
+        if self._state == STATE_ALARM_ARMED_AWAY and entity_id in self._away_sensors:
+            _LOGGER.info("Alarm triggered by %s in away mode", entity_id)
+            triggered = True
+        elif self._state == STATE_ALARM_ARMED_HOME and entity_id in self._home_sensors:
+            _LOGGER.info("Alarm triggered by %s in home mode", entity_id)
+            triggered = True
+        elif self._state == STATE_ALARM_ARMED_VACATION and entity_id in self._vacation_sensors:
+            _LOGGER.info("Alarm triggered by %s in vacation mode", entity_id)
+            triggered = True
+
+        if triggered:
+            self._state = STATE_ALARM_TRIGGERED
+            self.async_write_ha_state()
+
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm command."""
+        self._state = STATE_ALARM_DISARMED
+        self.async_write_ha_state()
+
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Send arm home command."""
+        self._state = STATE_ALARM_ARMED_HOME
+        self.async_write_ha_state()
+
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Send arm away command."""
+        self._state = STATE_ALARM_ARMED_AWAY
+        self.async_write_ha_state()
+
+    async def async_alarm_arm_vacation(self, code: str | None = None) -> None:
+        """Send arm vacation command."""
+        self._state = STATE_ALARM_ARMED_VACATION
+        self.async_write_ha_state()

--- a/custom_components/alarme_personnalisee/config_flow.py
+++ b/custom_components/alarme_personnalisee/config_flow.py
@@ -1,0 +1,55 @@
+"""Config flow for Alarme Personnalisée."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AlarmePersonnaliseeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Alarme Personnalisée."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            # Here you can add validation if needed before creating the entry.
+            # For now, we just create it.
+            return self.async_create_entry(title="Alarme Personnalisée", data=user_input)
+
+        # This is the form the user will see.
+        data_schema = vol.Schema(
+            {
+                vol.Optional("away_sensors"): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="binary_sensor", multiple=True
+                    ),
+                ),
+                vol.Optional("home_sensors"): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="binary_sensor", multiple=True
+                    ),
+                ),
+                vol.Optional("vacation_sensors"): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="binary_sensor", multiple=True
+                    ),
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )

--- a/custom_components/alarme_personnalisee/const.py
+++ b/custom_components/alarme_personnalisee/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Alarme Personnalisée integration."""
+
+DOMAIN = "alarme_personnalisee"

--- a/custom_components/alarme_personnalisee/manifest.json
+++ b/custom_components/alarme_personnalisee/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "alarme_personnalisee",
+  "name": "Alarme Personnalisée",
+  "version": "1.0.0",
+  "documentation": "https://github.com/user/repo",
+  "issue_tracker": "https://github.com/user/repo/issues",
+  "codeowners": [],
+  "config_flow": true,
+  "iot_class": "calculated",
+  "requirements": [],
+  "dependencies": []
+}

--- a/custom_components/alarme_personnalisee/strings.json
+++ b/custom_components/alarme_personnalisee/strings.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Custom Alarm Setup",
+        "description": "Please select the sensors for each alarm mode.",
+        "data": {
+          "away_sensors": "Sensors for Away Mode",
+          "home_sensors": "Sensors for Home Mode",
+          "vacation_sensors": "Sensors for Vacation Mode"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "This alarm is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Custom Alarm Options",
+        "description": "Update the sensors for each alarm mode.",
+        "data": {
+          "away_sensors": "Sensors for Away Mode",
+          "home_sensors": "Sensors for Home Mode",
+          "vacation_sensors": "Sensors for Vacation Mode"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/alarme_personnalisee/translations/fr.json
+++ b/custom_components/alarme_personnalisee/translations/fr.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configuration de l'Alarme Personnalisée",
+        "description": "Veuillez sélectionner les capteurs pour chaque mode d'alarme.",
+        "data": {
+          "away_sensors": "Capteurs pour le mode Absent",
+          "home_sensors": "Capteurs pour le mode Présent",
+          "vacation_sensors": "Capteurs pour le mode Vacances"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Cette alarme est déjà configurée."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options de l'Alarme Personnalisée",
+        "description": "Mettez à jour les capteurs pour chaque mode d'alarme.",
+        "data": {
+          "away_sensors": "Capteurs pour le mode Absent",
+          "home_sensors": "Capteurs pour le mode Présent",
+          "vacation_sensors": "Capteurs pour le mode Vacances"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces a new custom integration for Home Assistant to create a flexible alarm system.

The integration, named "Alarme Personnalisée", provides an alarm control panel entity with three distinct modes:
- Away Mode
- Home Mode
- Vacation Mode

Key features:
- **UI Configuration**: The integration is configured entirely through the Home Assistant UI (Config Flow). Users can select different sets of binary sensors (e.g., motion detectors, door/window sensors) for each of the three alarm modes.
- **Stateful Entity**: A robust `alarm_control_panel` entity that manages the states (`disarmed`, `armed_away`, `armed_home`, `armed_vacation`, `triggered`).
- **Sensor-based Triggering**: The alarm listens to the configured sensors and will enter the `triggered` state if a sensor is activated while the system is armed in a corresponding mode.
- **Internationalization (i18n)**: The configuration UI is available in English and French.

## Lovelace Card Configuration

To add this alarm to your Home Assistant dashboard, use the standard "Alarm Panel" card with the following YAML configuration:

```yaml
type: alarm-panel
entity: alarm_control_panel.alarme
states:
  - arm_home
  - arm_away
  - arm_vacation
```

This will provide a user-friendly interface with a keypad and buttons to arm and disarm the various modes of the alarm.